### PR TITLE
Add `car` and `sf`

### DIFF
--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -38,7 +38,9 @@ RUN mamba install --yes -c conda-forge \
 # R packages from CRAN (source)
 RUN R -e "install.packages(c( \
     'ggiraphExtra', \
-    'sandwich' \
+    'sandwich', \
+    'car', \
+    'sf' \
 ), repos='https://cloud.r-project.org')" && \
     R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/lisp/lisp_0.1.tar.gz', repos=NULL, type='source')" && \
     R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/translate/translate_0.1.2.tar.gz', repos=NULL, type='source')"


### PR DESCRIPTION
Add two CRAN packages (applied economics) and (simple features) to dockerfile.

* Will allow geographic computation via Jupyter (`sf`)
* Adds auxilary models for econometrics (`car`)