### PR TITLE
Add ai100-notebook image for AI100 course

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,37 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
           ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
         run: |
-          # List commits for debugging
-          echo "Previous SHA: ${{ github.event.before }}"
+          # Determine the base commit for the changed-files diff.
+          # github.event.before is the null SHA on a new branch's first push
+          # (and empty for pull_request events), which makes `git diff` abort
+          # with "fatal: bad object". Fall back to the merge-base with the
+          # default branch, then to the commit's first parent, so detection
+          # works for new branches, PRs, and normal pushes alike.
+          BEFORE="${{ github.event.before }}"
+          echo "Reported previous SHA: ${BEFORE:-<none>}"
           echo "Current SHA: ${{ github.sha }}"
 
-          # Get changed files between last and current commit
-          changed_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
+          if [ -z "$BEFORE" ] \
+             || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+             || ! git rev-parse --verify --quiet "${BEFORE}^{commit}" >/dev/null; then
+            git fetch --no-tags origin main >/dev/null 2>&1 || true
+            BASE=$(git merge-base origin/main "${{ github.sha }}" 2>/dev/null || true)
+            if [ -z "$BASE" ]; then
+              BASE=$(git rev-parse --verify --quiet "${{ github.sha }}^" || true)
+            fi
+          else
+            BASE="$BEFORE"
+          fi
+
+          # Get changed files between the resolved base and the current commit.
+          if [ -n "$BASE" ]; then
+            echo "Diffing against base: $BASE"
+            changed_files=$(git diff --name-only "$BASE" "${{ github.sha }}")
+          else
+            # Root commit with no parent: treat every tracked file as changed.
+            echo "No diff base found; treating all tracked files as changed."
+            changed_files=$(git ls-tree -r --name-only "${{ github.sha }}")
+          fi
 
           echo "Changed files:"
           echo "$changed_files"

--- a/ai100-notebook/Dockerfile
+++ b/ai100-notebook/Dockerfile
@@ -1,0 +1,77 @@
+ARG BASE_CONTAINER=quay.io/jupyter/scipy-notebook:hub-5.5.0
+FROM $BASE_CONTAINER
+
+LABEL maintainer="Jeff Longland <jeff.longland@ubc.ca>"
+LABEL course="AI100"
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    wget \
+    unzip \
+    git \
+    tzdata \
+    wkhtmltopdf && \
+    apt-get clean && \
+    apt-get autoremove -y
+
+# Install Node.js 22 LTS via NodeSource (needed for the AI coding CLIs)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean
+
+# Install AI coding agents. For each agent we install both:
+#   - the standalone CLI (for terminal use), and
+#   - the ACP adapter, which is how jupyter-ai v3 surfaces the agent as a chat
+#     persona (jupyter-ai's ACP *client* is pulled in by the pip step below).
+RUN npm install -g \
+        @anthropic-ai/claude-code \
+        @zed-industries/claude-agent-acp \
+        @openai/codex \
+        @zed-industries/codex-acp
+
+USER ${NB_UID}
+
+# Common JupyterLab extensions / tooling (includes nbgitpuller)
+USER root
+COPY install-common.sh /tmp/install-common.sh
+RUN chown jovyan:users /tmp/install-common.sh && chmod +x /tmp/install-common.sh
+USER ${NB_UID}
+RUN /bin/bash -x /tmp/install-common.sh
+
+# Python packages: jupyter-ai, jupyter-server-proxy, and GizmoApp runtime deps.
+#
+# jupyter-ai 3.x drives coding agents over ACP; it pulls in jupyter-ai-acp-client
+# automatically, so the npm ACP adapters above (claude-agent-acp / codex-acp)
+# appear as chat personas with no extra pip package. Pinned to <4 so a future
+# major release can't silently change the agent stack under the course.
+# jupyter-ai-jupyternaut adds the default (direct-LLM) Jupyternaut chat persona.
+# GizmoApp's runtime deps are Flask + gunicorn (+ optional scikit-learn for ML),
+# installed here so the nbgitpuller'd copy runs immediately via server-proxy.
+RUN pip install --no-cache-dir \
+    jupyter-server-proxy \
+    "jupyter-ai>=3.0,<4.0" \
+    jupyter-ai-jupyternaut \
+    openai \
+    anthropic \
+    "Flask>=3.0,<4.0" \
+    "gunicorn>=23.0,<24.0" \
+    "scikit-learn>=1.4,<2.0"
+
+# GizmoApp launcher: server-proxy starts it on demand from the student's
+# nbgitpuller'd ~/GizmoApp copy and serves it under the Jupyter base URL.
+USER root
+COPY ai100-notebook/start-gizmoapp.sh /usr/local/bin/start-gizmoapp.sh
+COPY ai100-notebook/gizmoapp_server_proxy_config.py /tmp/gizmoapp_server_proxy_config.py
+RUN chmod 755 /usr/local/bin/start-gizmoapp.sh && \
+    cat /tmp/gizmoapp_server_proxy_config.py >> /etc/jupyter/jupyter_server_config.py && \
+    rm /tmp/gizmoapp_server_proxy_config.py
+
+# Fix ownership in case root touched files
+RUN chown -R jovyan:users /home/jovyan
+
+USER jovyan
+ENV HOME=/home/jovyan
+WORKDIR $HOME

--- a/ai100-notebook/README.md
+++ b/ai100-notebook/README.md
@@ -1,0 +1,61 @@
+# ai100-notebook
+
+JupyterHub single-user image for **AI100**.
+
+Built on `quay.io/jupyter/scipy-notebook:hub-5.5.0` and adds:
+
+- **AI coding agents** (installed globally via Node 22), each as both a
+  terminal CLI and an ACP adapter for jupyter-ai:
+  - Claude Code — `@anthropic-ai/claude-code` (CLI) + `@zed-industries/claude-agent-acp` (ACP)
+  - Codex — `@openai/codex` (CLI) + `@zed-industries/codex-acp` (ACP)
+- **jupyter-ai 3.x** (`>=3.0,<4.0`), plus `jupyter-ai-jupyternaut` and the
+  `openai`/`anthropic` Python SDKs. jupyter-ai v3 connects to coding agents over
+  the Agent Client Protocol (ACP); it pulls in `jupyter-ai-acp-client`
+  automatically, so the two ACP adapters above show up as chat personas.
+- **jupyter-server-proxy** wired to launch **GizmoApp** on demand.
+- Common JupyterLab tooling from `install-common.sh` (includes `nbgitpuller`).
+
+## How students get GizmoApp
+
+The [GizmoApp repo](https://github.com/kevinlb1/GizmoApp) is **not baked into
+the image**. Students pull it into their home directory with an nbgitpuller
+link, which lands it at `~/GizmoApp`:
+
+```
+https://<HUB_HOST>/hub/user-redirect/git-pull?repo=https://github.com/kevinlb1/GizmoApp&branch=main&urlpath=lab
+```
+
+Replace `<HUB_HOST>` with the AI100 hub hostname. This URL-encoded form is
+ready to paste into a Canvas/LMS link or the course site. nbgitpuller is
+merge-friendly, so re-clicking the link pulls instructor updates without
+clobbering student work.
+
+## Running GizmoApp
+
+Once `~/GizmoApp` exists, GizmoApp appears as a **GizmoApp** tile in the
+JupyterLab launcher (provided by jupyter-server-proxy). Clicking it:
+
+1. runs `/usr/local/bin/start-gizmoapp.sh <port>`,
+2. which starts `gunicorn server.wsgi:app` from `~/GizmoApp`, and
+3. serves it under `<base_url>/gizmoapp/` inside the JupyterLab tab.
+
+GizmoApp's `create_app()` runs its idempotent SQLite migrations on startup, so
+no separate database init step is required. The database is written to
+`~/GizmoApp/var/data/` (git-ignored in the repo).
+
+It can also be reached directly at `…/user/<name>/gizmoapp/`.
+
+## Build / deploy
+
+CI (`.github/workflows/build.yml`) builds from the **repo root** as the Docker
+context and pushes to ECR as `ai100-notebook` (`:latest` and the commit SHA)
+whenever files under `ai100-notebook/` change. The Dockerfile therefore
+references `install-common.sh` and `ai100-notebook/…` relative to the repo
+root.
+
+### Local build
+
+```bash
+# from the jupyter-images repo root
+docker build -f ai100-notebook/Dockerfile -t ai100-notebook:dev .
+```

--- a/ai100-notebook/gizmoapp_server_proxy_config.py
+++ b/ai100-notebook/gizmoapp_server_proxy_config.py
@@ -1,0 +1,24 @@
+
+# --- AI100: GizmoApp via jupyter-server-proxy -------------------------------
+# Appended to /etc/jupyter/jupyter_server_config.py at image build time.
+# `c` is already defined by the base config file above.
+#
+# GizmoApp is path-prefix aware (GIZMOAPP_URL_PREFIX). We run it with
+# absolute_url=True and hand it the full proxied prefix ({base_url}gizmoapp)
+# so its generated static/API links resolve correctly behind the proxy.
+c.ServerProxy.servers = {
+    "gizmoapp": {
+        "command": ["/usr/local/bin/start-gizmoapp.sh", "{port}"],
+        "environment": {
+            "GIZMOAPP_URL_PREFIX": "{base_url}gizmoapp",
+            "GIZMOAPP_SHELL": "auto",
+        },
+        "absolute_url": True,
+        "timeout": 60,
+        "launcher_entry": {
+            "title": "GizmoApp",
+            "enabled": True,
+        },
+        "new_browser_tab": False,
+    }
+}

--- a/ai100-notebook/start-gizmoapp.sh
+++ b/ai100-notebook/start-gizmoapp.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Launch GizmoApp for jupyter-server-proxy.
+#
+# Invoked as: start-gizmoapp.sh <port>
+# jupyter-server-proxy substitutes {port} and sets GIZMOAPP_URL_PREFIX in the
+# environment so GizmoApp generates links under the proxied Jupyter base URL.
+#
+# GizmoApp lives in the student's home directory after an nbgitpuller pull.
+set -euo pipefail
+
+PORT="${1:-8001}"
+APP_DIR="${GIZMOAPP_DIR:-${HOME}/GizmoApp}"
+
+if [ ! -d "${APP_DIR}" ]; then
+    echo "GizmoApp is not present at ${APP_DIR}." >&2
+    echo "Use the nbgitpuller link to pull the repo, then start GizmoApp again." >&2
+    exit 1
+fi
+
+cd "${APP_DIR}"
+
+# server.wsgi calls create_app(), which runs the (idempotent) DB migrations on
+# import, so no separate init step is needed. --chdir keeps the `server`
+# package importable for gunicorn.
+exec gunicorn \
+    --chdir "${APP_DIR}" \
+    --bind "127.0.0.1:${PORT}" \
+    --workers 2 \
+    --timeout 120 \
+    server.wsgi:app


### PR DESCRIPTION
## Summary

New JupyterHub single-user image for the **AI100** course, built on `quay.io/jupyter/scipy-notebook:hub-5.5.0` (matching the existing scipy/tensorflow images). On merge, CI auto-creates the `ai100-notebook` ECR repo and pushes `:latest` + the commit SHA.

### What's included
- **AI coding agents** — each as both a terminal CLI and a jupyter-ai ACP persona:
  - Claude Code: `@anthropic-ai/claude-code` (CLI) + `@zed-industries/claude-agent-acp` (ACP)
  - Codex: `@openai/codex` (CLI) + `@zed-industries/codex-acp` (ACP)
- **jupyter-ai 3.x** (pinned `>=3.0,<4.0`) — v3 drives coding agents over the Agent Client Protocol and pulls in `jupyter-ai-acp-client` automatically, so the two ACP adapters appear as chat personas. Includes `jupyter-ai-jupyternaut` and the `openai`/`anthropic` SDKs.
- **jupyter-server-proxy** wired to launch **GizmoApp** on demand.
- Common tooling from `install-common.sh` (includes `nbgitpuller`).

### GizmoApp delivery
GizmoApp is **not baked in**. Students pull it to `~/GizmoApp` via an nbgitpuller link; it then appears as a **GizmoApp** tile in the JupyterLab launcher. server-proxy runs `gunicorn server.wsgi:app` from the pulled copy and serves it under the Jupyter base URL using GizmoApp's `GIZMOAPP_URL_PREFIX` support (`absolute_url: True`). `create_app()` runs idempotent SQLite migrations on startup, so no separate DB-init step is needed. GizmoApp's runtime deps (Flask, gunicorn, scikit-learn) are baked in so the pulled repo runs immediately.

nbgitpuller link (replace `<HUB_HOST>`):
```
https://<HUB_HOST>/hub/user-redirect/git-pull?repo=https://github.com/kevinlb1/GizmoApp&branch=main&urlpath=lab
```

## Notes / follow-ups
- **Bleeding edge:** jupyter-ai 3.0.0 is a brand-new major release and `jupyter-ai-acp-client` is still proof-of-concept. Recommend a smoke-test build before classroom use; can hard-pin exact versions afterward.
- **API keys:** ACP personas need `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` in the environment — to be wired into the AI100 hub profile separately.

## Test plan
- [ ] CI builds `ai100-notebook` and pushes to ECR
- [ ] Launch a server; confirm `claude` and `codex` CLIs work in a terminal
- [ ] Confirm Claude/Codex personas appear in jupyter-ai chat
- [ ] Pull GizmoApp via nbgitpuller; click the GizmoApp launcher tile; confirm it serves under the proxied path

🤖 Generated with [Claude Code](https://claude.com/claude-code)